### PR TITLE
add missing required permission_callback argument

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -81,6 +81,7 @@ class Controller
                         },
                     ],
                 ],
+                'permission_callback' => '__return_true',
             ]
         );
     }


### PR DESCRIPTION
The permission_callback is required from WP 5.5.0.