### PR TITLE
Bump dependencies for Laravel 10 - support v1 and v2 composer/installers and laravel 9 and 10 for acorn 3/4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,31 @@
 {
-  "name": "triggerfish/rest-ajax",
-  "type": "wordpress-muplugin",
-  "license": "MIT",
-  "homepage": "https://www.triggerfish.se",
-  "authors": [
-    {
-      "name": "Joi Glifberg",
-      "email": "joi@triggerfish.se",
-      "homepage": "https://github.com/circuuz"
+    "name": "triggerfish/rest-ajax",
+    "type": "wordpress-muplugin",
+    "license": "MIT",
+    "homepage": "https://www.triggerfish.se",
+    "authors": [
+        {
+            "name": "Joi Glifberg",
+            "email": "joi@triggerfish.se",
+            "homepage": "https://github.com/circuuz"
+        }
+    ],
+    "keywords": [
+        "wordpress"
+    ],
+    "autoload": {
+        "psr-4": {
+            "Triggerfish\\REST_Ajax\\": "src/"
+        }
+    },
+    "require": {
+        "php": ">=8.0",
+        "composer/installers": "~1.0|^2.2",
+        "illuminate/support": "9.28.*|^10.0"
+    },
+    "scripts": {
+        "test": [
+            "vendor/bin/phpcs --extensions=php --ignore=vendor/ -n -s ."
+        ]
     }
-  ],
-  "keywords": [
-    "wordpress"
-  ],
-  "autoload": {
-    "psr-4": {
-      "Triggerfish\\REST_Ajax\\": "src/"
-    }
-  },
-  "require": {
-    "php": ">=8.0",
-    "composer/installers": "~1.0",
-    "illuminate/support": "9.28.*"
-  },
-  "scripts": {
-    "test": [
-      "vendor/bin/phpcs --extensions=php --ignore=vendor/ -n -s ."
-    ]
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "composer/installers": "~1.0|^2.2",
+        "composer/installers": "^1.0|^2.0",
         "illuminate/support": "9.28.*|^10.0"
     },
     "scripts": {


### PR DESCRIPTION
support v1 and v2 composer/installers and laravel 9 and 10 for acorn 3/4.

Needs Testing!