### PR TITLE
Merge JSON body into handler params; harden REST/Polylang handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Automatic templating can be achieved.
 2. If a class cannot be found by 1, the fallback will be searched for. The fallback is a public static method named like the action in camelCase in `App\AjaxHandler\DefaultHandler`. This is what is called "method based" handler below.
 
 3. Automatic templating.
-   If the data from 1 or 2 is an array, a template named like the action in kebab-case will be searched forin a directory called "ajax" in the views directory.
+   If the data from 1 or 2 is an array, a template named like the action in kebab-case will be searched for in a directory called "ajax" in the views directory.
 
    But if the handler is "class based", the class can define a public method named `__template` that return the preferred template's path. This will take precedence over, and fall back to, the template in the "ajax" directory from above.
 
@@ -41,3 +41,36 @@ Automatic templating can be achieved.
 - tf/ajax/result/action=XX
 - tf/ajax/template_paths
 - tf/ajax/template_paths/action=XX
+
+## JSON request body and handler params
+
+For `POST` requests with `Content-Type: application/json`, WordPress exposes the decoded body via `WP_REST_Request::get_json_params()`. Class-based handlers merge those values into the usual query/form params (later JSON keys override) and store the result on `AbstractAjaxHandler::$params`, so nested structures are real PHP arrays instead of `stdClass` objects (which avoids `foreach` type issues on PHP 8+).
+
+The keys `searchArgs` and `taxonomyFilters` are normalized: existing arrays are kept as-is; objects are converted to arrays via JSON encode/decode; any other type becomes an empty array `[]`.
+
+## Polylang
+
+When Polylang is active, the controller sets the current language for the AJAX request in a context-aware way: **REST** contexts (`PLL_REST_Request`) use the language model only (no URL chooser). **Frontend** contexts use `PLL_Choose_Lang_Url` and the preferred language. Other Polylang setups fall back to resolving the language from the model.
+
+## REST error responses
+
+Failures are returned as REST errors with these `code` values (useful when debugging in the browser network panel or logs):
+
+| Code | When |
+|------|------|
+| `rest_ajax_exception` | Uncaught exception or error while handling the request |
+| `rest_ajax_validate` | Exception during `action` validation |
+| `rest_ajax_template` | Exception while rendering the template |
+| `no_handler` | No callable handler was resolved (should be rare) |
+
+When `WP_DEBUG` is true, the error `message` may include the underlying exception message.
+
+## Version and releases
+
+The plugin header in `rest-ajax-plugin.php` carries the current version. Release builds use a **git tag** (for example `1.2.0`); keep the header in sync when tagging.
+
+### 1.2.0
+
+- Merge JSON body parameters into class-based handler params; normalize `searchArgs` / `taxonomyFilters` for PHP 8.
+- Polylang: correct handling for REST (`PLL_REST_Request`) vs frontend.
+- Harden REST flow with try/catch, structured `WP_Error` responses, and safer handler class validation (invalid base class fails validation instead of `E_USER_ERROR`).

--- a/rest-ajax-plugin.php
+++ b/rest-ajax-plugin.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 /*
 Plugin Name:  REST Ajax
+Version:      1.2.0
 Author:       Triggerfish
 Author URI:   https://www.triggerfish.se/
 License:      MIT License

--- a/src/AbstractAjaxHandler.php
+++ b/src/AbstractAjaxHandler.php
@@ -5,6 +5,13 @@ namespace Triggerfish\REST_Ajax;
 
 use WP_REST_Request;
 
+/**
+ * Handlers read merged REST params in {@see AbstractAjaxHandler::$params}.
+ *
+ * JSON bodies (application/json) expose fields via {@see WP_REST_Request::get_json_params()}.
+ * Those are merged into query/form params so nested keys are real PHP arrays. Without that step,
+ * a JSON object can surface as a stdClass, which breaks foreach on PHP 8+.
+ */
 abstract class AbstractAjaxHandler implements AjaxHandlerInterface
 {
     protected $request;
@@ -13,7 +20,37 @@ abstract class AbstractAjaxHandler implements AjaxHandlerInterface
     final public function __construct(WP_REST_Request $request)
     {
         $this->request = $request;
-        $this->params = $this->request->get_params();
+        $params = $this->request->get_params();
+        $jsonParams = $this->request->get_json_params();
+        if (is_array($jsonParams) && $jsonParams !== []) {
+            $params = array_replace($params, $jsonParams);
+        }
+        $this->params = self::normalizeNestedBodyParams($params);
+    }
+
+    /**
+     * @param  array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    protected static function normalizeNestedBodyParams(array $params): array
+    {
+        foreach (['searchArgs', 'taxonomyFilters'] as $key) {
+            if (! array_key_exists($key, $params)) {
+                continue;
+            }
+            $value = $params[$key];
+            if (is_array($value)) {
+                continue;
+            }
+            if (is_object($value)) {
+                $decoded = json_decode(wp_json_encode($value), true);
+                $params[$key] = is_array($decoded) ? $decoded : [];
+                continue;
+            }
+            $params[$key] = [];
+        }
+
+        return $params;
     }
 
     // Always use / as directory separator, not . as in Blade templates.

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -71,14 +71,31 @@ class Controller
                 'callback' => function (WP_REST_Request $request) {
                     $instance = new self($request);
 
-                    return $instance->handleRequest();
+                    return $instance->dispatchRequest();
                 },
                 'args' => [
                     'action' => [
                         'type' => 'string',
                         'required' => true,
                         'validate_callback' => function ($action, $request) {
-                            return self::hasCallableHandler($action, $request);
+                            try {
+                                return self::hasCallableHandler($action, $request);
+                            } catch (\Throwable $e) {
+                                error_log(
+                                    sprintf(
+                                        'REST Ajax validate: %s in %s:%d',
+                                        $e->getMessage(),
+                                        $e->getFile(),
+                                        $e->getLine()
+                                    )
+                                );
+
+                                return new WP_Error(
+                                    'rest_ajax_validate',
+                                    (defined('WP_DEBUG') && WP_DEBUG) ? $e->getMessage() : 'Validation failed.',
+                                    ['status' => 500]
+                                );
+                            }
                         },
                     ],
                 ],
@@ -93,21 +110,93 @@ class Controller
         $this->action = $this->request->get_param('action');
     }
 
+    protected function dispatchRequest()
+    {
+        try {
+            return $this->handleRequest();
+        } catch (\Throwable $e) {
+            error_log(
+                sprintf(
+                    'REST Ajax exception: %s in %s:%d',
+                    $e->getMessage(),
+                    $e->getFile(),
+                    $e->getLine()
+                )
+            );
+
+            return new WP_Error(
+                'rest_ajax_exception',
+                (defined('WP_DEBUG') && WP_DEBUG) ? $e->getMessage() : 'Request failed.',
+                ['status' => 500]
+            );
+        }
+    }
+
+    protected static function setPolylangCurlangFromModel(object $pll): void
+    {
+        if (! isset($pll->model) || ! is_object($pll->model)) {
+            return;
+        }
+
+        $model = $pll->model;
+        $lang = null;
+
+        if (method_exists($model, 'get_language_from_request')) {
+            $slug = $model->get_language_from_request();
+            if ($slug) {
+                $lang = $model->get_language($slug);
+            }
+        }
+
+        if (! $lang && method_exists($model, 'get_default_language')) {
+            $default = $model->get_default_language();
+            if ($default) {
+                $lang = $model->get_language($default);
+            }
+        }
+
+        if (is_object($lang) && isset($lang->slug)) {
+            $pll->curlang = $lang;
+            $GLOBALS['text_direction'] = (isset($lang->is_rtl) && $lang->is_rtl) ? 'rtl' : 'ltr';
+        }
+    }
+
+    protected static function maybeSetPolylangLanguageForAjax(): void
+    {
+        if (! function_exists('PLL')) {
+            return;
+        }
+
+        $pll = PLL();
+
+        if (class_exists(\PLL_REST_Request::class) && $pll instanceof \PLL_REST_Request) {
+            self::setPolylangCurlangFromModel($pll);
+
+            return;
+        }
+
+        if (class_exists(\PLL_Frontend::class) && $pll instanceof \PLL_Frontend) {
+            if (class_exists(\PLL_Choose_Lang_Url::class)) {
+                $choose_lang = new \PLL_Choose_Lang_Url($pll);
+                $lang = $choose_lang->get_preferred_language();
+
+                if (is_object($lang) && isset($lang->slug)) {
+                    $pll->curlang = $lang;
+                    $GLOBALS['text_direction'] = (isset($lang->is_rtl) && $lang->is_rtl) ? 'rtl' : 'ltr';
+                }
+            }
+
+            return;
+        }
+
+        self::setPolylangCurlangFromModel($pll);
+    }
+
     protected function handleRequest()
     {
         add_filter('wp_doing_ajax', '__return_true');
 
-        // Fix to set the current language in Polylang.
-        if (function_exists('PLL') && class_exists('PLL_Choose_Lang_Url')) {
-            $pll = PLL();
-            $choose_lang = new \PLL_Choose_Lang_Url($pll);
-            $lang = $choose_lang->get_preferred_language();
-
-            if (pll_current_language() != $lang) {
-                PLL()->curlang = $lang;
-                $GLOBALS['text_direction'] = PLL()->curlang->is_rtl ? 'rtl' : 'ltr';
-            }
-        }
+        self::maybeSetPolylangLanguageForAjax();
 
         do_action('tf/ajax/before', $this->action, $this->request);
         do_action('tf/ajax/before/action=' . $this->action, $this->action);
@@ -115,11 +204,34 @@ class Controller
 
         $result = $this->getHandlerData($this->action, $this->request->get_params());
 
+        if (is_wp_error($result)) {
+            return rest_ensure_response($result);
+        }
+
         if (is_array($result) || (is_object($result) && $result instanceof ArrayAccess)) {
             $template = $this->getTemplate();
 
             if (! empty($template)) {
-                $result = template($template, $result);
+                try {
+                    $result = template($template, $result);
+                } catch (\Throwable $e) {
+                    error_log(
+                        sprintf(
+                            'REST Ajax template: %s in %s:%d',
+                            $e->getMessage(),
+                            $e->getFile(),
+                            $e->getLine()
+                        )
+                    );
+
+                    return rest_ensure_response(
+                        new WP_Error(
+                            'rest_ajax_template',
+                            (defined('WP_DEBUG') && WP_DEBUG) ? $e->getMessage() : 'Template rendering failed.',
+                            ['status' => 500]
+                        )
+                    );
+                }
             }
         }
 
@@ -213,16 +325,19 @@ class Controller
             return false;
         }
 
-        if (! is_subclass_of(self::getActionClass($action), 'Triggerfish\REST_Ajax\AbstractAjaxHandler')) {
-            trigger_error(
-                sprintf(
-                    '%s must extend class Triggerfish\REST_Ajax\AbstractAjaxHandler.',
-                    self::getActionClass($action)
-                ),
-                E_USER_ERROR
-            );
-        }
+        if (! is_subclass_of($className, AbstractAjaxHandler::class)) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log(
+                    sprintf(
+                        '%s must extend class %s.',
+                        $className,
+                        AbstractAjaxHandler::class
+                    )
+                );
+            }
 
+            return false;
+        }
 
         return true;
     }
@@ -260,6 +375,9 @@ class Controller
         return null;
     }
 
+    /** @var array<string, AbstractAjaxHandler> */
+    protected $actionClassInstances = [];
+
     protected function getActionClassInstance() : ?AbstractAjaxHandler
     {
 
@@ -267,25 +385,29 @@ class Controller
             return null;
         }
 
-        static $instance;
-
-        if (is_null($instance)) {
+        if (! isset($this->actionClassInstances[$this->action])) {
             $class = self::getActionClass($this->action);
-            $instance = new $class($this->request);
+            $this->actionClassInstances[$this->action] = new $class($this->request);
         }
 
-        return $instance;
+        return $this->actionClassInstances[$this->action];
     }
 
     protected function getHandlerData(string $action)
     {
+        $handler = $this->getCallabeHandler();
+        if ($handler === null) {
+            return new WP_Error(
+                'no_handler',
+                'No handler found for this action.',
+                ['status' => 500]
+            );
+        }
+
         // Send all extra arguments to getHandlerData() onwards to the actual handler.
         $args = func_get_args();
         $extra_arguments = collect($args)->slice(1)->all();
 
-        return call_user_func_array(
-            $this->getCallabeHandler(),
-            $extra_arguments
-        );
+        return call_user_func_array($handler, $extra_arguments);
     }
 }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -361,7 +361,7 @@ class Controller
         return false;
     }
 
-    protected function getCallabeHandler(): ?callable
+    protected function getCallableHandler(): ?callable
     {
 
         if (self::hasClassBasedHandler($this->action, $this->request)) {
@@ -395,7 +395,7 @@ class Controller
 
     protected function getHandlerData(string $action)
     {
-        $handler = $this->getCallabeHandler();
+        $handler = $this->getCallableHandler();
         if ($handler === null) {
             return new WP_Error(
                 'no_handler',


### PR DESCRIPTION
- AbstractAjaxHandler: array_replace JSON params; normalize searchArgs/taxonomyFilters
- Controller: dispatchRequest try/catch; Polylang REST vs frontend paths; validate/template error codes; no_handler; handler class validation without E_USER_ERROR; per-action handler instances per request